### PR TITLE
[FIX][l10n_it_fatturapa_out] related documents didn't get saved properly

### DIFF
--- a/l10n_it_fatturapa_out/views/account_view.xml
+++ b/l10n_it_fatturapa_out/views/account_view.xml
@@ -34,6 +34,7 @@
                                 <field name="code" />
                                 <field name="cig" />
                                 <field name="cup" />
+                                <field name="invoice_id" invisible="1"/>
                             </tree>
                         </field>
                     </group>


### PR DESCRIPTION
The was no invoice_id among the fields on that embedded tree, then the related document records didn't get linked to the invoice once saved.

PS: IMO, this related documents thing would need a refactoring



--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
