### PR TITLE
[14.0][l10n_it_withholding_tax]

### DIFF
--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -364,7 +364,7 @@ class AccountMove(models.Model):
         readonly=True,
     )
 
-    @api.onchange("line_ids")
+    @api.onchange("invoice_line_ids")
     def _onchange_invoice_line_wt_ids(self):
         self.ensure_one()
         wt_taxes_grouped = self.get_wt_taxes_values()
@@ -419,10 +419,11 @@ class AccountMove(models.Model):
         for invoice in self:
             for line in invoice.invoice_line_ids:
                 taxes = []
-                for wt_tax in line.invoice_line_tax_wt_ids.filtered(lambda x: x.id):
+                for wt_tax in line.invoice_line_tax_wt_ids.filtered(
+                        lambda x: x._origin.id):
                     res = wt_tax.compute_tax(line.price_subtotal)
                     tax = {
-                        "id": wt_tax.id,
+                        "id": wt_tax._origin.id,
                         "sequence": wt_tax.sequence,
                         "base": res["base"],
                         "tax": res["tax"],

--- a/l10n_it_withholding_tax/models/account.py
+++ b/l10n_it_withholding_tax/models/account.py
@@ -51,7 +51,11 @@ class AccountPartialReconcile(models.Model):
         if vals.get("credit_move_id"):
             ml_ids.append(vals.get("credit_move_id"))
         move_lines = self.env["account.move.line"].browse(ml_ids)
-        invoice = move_lines.filtered(lambda x: x.exists()).move_id
+        for ml in move_lines:
+            domain = [('id', '=', ml.move_id.id)]
+            invoice = self.env['account.move'].search(domain)
+            if invoice:
+                break
         # invoice.ensure_one() XXX - should we do this?
         # Limit value of reconciliation
         if invoice and invoice.withholding_tax and invoice.amount_net_pay:

--- a/l10n_it_withholding_tax/models/withholding_tax.py
+++ b/l10n_it_withholding_tax/models/withholding_tax.py
@@ -18,7 +18,7 @@ class WithholdingTax(models.Model):
         for wt in self:
             wt.tax = 0
             wt.base = 1
-            if not wt.id:
+            if not wt._origin.id:
                 continue
             self.env.cr.execute(
                 """
@@ -27,7 +27,7 @@ class WithholdingTax(models.Model):
                      and (date_start <= current_date or date_start is null)
                      and (date_stop >= current_date or date_stop is null)
                     ORDER by date_start LIMIT 1""",
-                (wt.id,),
+                (wt._origin.id,),
             )
             rate = self.env.cr.fetchone()
             if rate:


### PR DESCRIPTION
Scelte tecniche da verificare.
Ho fatto il revert a ciò che faceva v12 per la questione del singleton error e poi ho dovuto usare ._origin.id invece di .id nei casi che vedi.
Testato e funzionalmente funzionante




--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
