### PR TITLE
[FIX] l10n_it_fatturapa: Compute correct tax for repartition lines of demo taxes

### DIFF
--- a/l10n_it_fatturapa/demo/account_invoice_fatturapa.xml
+++ b/l10n_it_fatturapa/demo/account_invoice_fatturapa.xml
@@ -9,6 +9,7 @@
             <field name="type_tax_use">sale</field>
             <field
                 name="invoice_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -17,12 +18,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />
             <field
                 name="refund_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -31,7 +33,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />
@@ -44,6 +46,7 @@
             <field name="type_tax_use">sale</field>
             <field
                 name="invoice_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -52,12 +55,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />
             <field
                 name="refund_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -66,7 +70,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />
@@ -79,6 +83,7 @@
             <field name="type_tax_use">purchase</field>
             <field
                 name="invoice_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -87,12 +92,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.1601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_receivable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_assets')], limit=1),
+                    'account_id': ref('l10n_it.1601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_receivable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_assets'))], limit=1),
                 }),
             ]"
             />
             <field
                 name="refund_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -101,7 +107,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.1601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_receivable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_assets')], limit=1),
+                    'account_id': ref('l10n_it.1601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_receivable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_assets'))], limit=1),
                 }),
             ]"
             />
@@ -115,6 +121,7 @@
             <field name="type_tax_use">sale</field>
             <field
                 name="invoice_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -123,12 +130,13 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />
             <field
                 name="refund_repartition_line_ids"
+                model="account.tax.repartition.line"
                 eval="[(5, 0, 0),
                 (0,0, {
                     'factor_percent': 100,
@@ -137,7 +145,7 @@
                 (0,0, {
                     'factor_percent': 100,
                     'repartition_type': 'tax',
-                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or ref('account.account').search([('user_type_id', '=', 'account.data_account_type_current_liabilities')], limit=1),
+                    'account_id': ref('l10n_it.2601', raise_if_not_found=False) or ref('l10n_generic_coa.tax_payable', raise_if_not_found=False) or obj().env['account.account'].search([('user_type_id', '=', ref('account.data_account_type_current_liabilities'))], limit=1),
                 }),
             ]"
             />


### PR DESCRIPTION
`ref('account.account')` non esiste perché non è un dato creato da un modello: forse volevi ottenere `ref('account.model_account_account')` ma anche questo non andrebbe bene perché restituirebbe semplicemente l'`id` del model dei conti.

A noi serve invece il model vero e proprio: quello nel Environment che in altri punti (tipo https://github.com/odoo/odoo/blob/600a1da6c327064e83feed122092c5d0ce1e7894/addons/l10n_ar/demo/account_supplier_invoice_demo.xml#L146) è chiamato `obj`.

`model` serve per avere `obj` tra le variabili disponibili: `model` viene letto in https://github.com/odoo/odoo/blob/d0cbe52c111af923f0df5d0d231b164a150bf2db/odoo/tools/convert.py#L89 e poi `obj` viene aggiunto alle variabili in https://github.com/odoo/odoo/blob/d0cbe52c111af923f0df5d0d231b164a150bf2db/odoo/tools/convert.py#L65.

--
Confermo di aver firmato il CLA https://odoo-community.org/page/cla e di aver letto le linee guida su https://odoo-community.org/page/contributing
